### PR TITLE
Better date parsing, support for excerpts, and entry[:basename]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_posts
+scratch

--- a/README.markdown
+++ b/README.markdown
@@ -19,6 +19,10 @@ And maybe you want to move it into Jekyll too? That's also easy:
         puts "Done processing: #{entry[:title]}"
     end
   
+In fact, running this command will convert an export archive to Jekyll posts into `_posts`:
+
+    ruby mt_to_jekyll.rb <path-to-export>
+
 Viola!
 
   [1]: http://www.sixapart.com/movabletype/docs/mtimport


### PR DESCRIPTION
Here are some updates I made to successfully convert my blog into something Octopress/Jekyll could handle:

```
- Switch from Time to DateTime to parse the dates using 'month/day/year'.
- Turn :extended_body into excerpts.
- Use 'date' vs. 'datetime' in the YAML front matter.
- Use entry[:basename] as the permalink, if it exists.
```

I also updated the README to mention the command line usage of mt_to_jekyll.rb.
