### PR TITLE
Updating respond_to? to search private and protected methods. Adding image path support.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,13 @@ First, you'll need to [export][1] your blog and put it into a convenient data st
     mt.parse
     mt.print_summary
 
+You may want to generate a list of images so you can download them too:
+
+    file = File.read("mtexport.dump")
+    mt = MtexportParser.new(file)
+    mt.parse
+    mt.print_fullsize_images
+
 And maybe you want to move it into Jekyll too? That's also easy:
 
     file = File.read("mtexport.dump")

--- a/example.dump
+++ b/example.dump
@@ -55,3 +55,23 @@ DATE: 01/31/2002 04:23:01 PM
 Here is the first comment on this entry.
 -----
 --------
+TITLE: Here is an entry with images
+AUTHOR: Bear Baz
+DATE: 01/31/2014 03:31:05
+CATEGORY: Politics
+-----
+BODY:
+This is the body of the second entry. It can
+consist of multiple lines. <a class="asset-img-link" href="http://www.foo.com/.a/reallycrypticstringoflettersandnumbers-popup" onclick="window.open( this.href, &#39;_blank&#39;, &#39;width=640,height=480,scrollbars=no,resizable=no,toolbar=no,directories=no,location=no,menubar=no,status=no,left=0,top=0&#39; ); return false"><span class="asset  asset-image at-xid-reallycrypticstringoflettersandnumbers img-responsive">View this photo</span></a>
+-----
+EXCERPT:
+See, this entry does not have an extended piece; but
+it does have an excerpt. It is special. <a class="asset-img-link" href="http://www.foo.com/.a/anotherreallycrypticstringoflettersandnumbers-popup" onclick="window.open( this.href, &#39;_blank&#39;, &#39;width=640,height=480,scrollbars=no,resizable=no,toolbar=no,directories=no,location=no,menubar=no,status=no,left=0,top=0&#39; ); return false" style="display: inline;"><img alt="Bill_Hang PS" class="asset  asset-image at-xid-anotherreallycrypticstringoflettersandnumbers img-responsive" src="http://www.foo.com/.a/anotherreallycrypticstringoflettersandnumbers-450wi" style="width: 450px;" title="Bear Baz" /></a>
+-----
+COMMENT:
+AUTHOR: Quux
+URL: http://www.quux.com/
+DATE: 01/31/2014 04:23:01 PM
+Here is the first comment on this entry.
+-----
+--------

--- a/mtexport_parser.rb
+++ b/mtexport_parser.rb
@@ -81,7 +81,7 @@ class MtexportParser
 
       name = "#{key.downcase.gsub(' ', '_')}"
       method = "process_#{name}"
-      if self.respond_to?(method)
+      if self.respond_to?(method,true)
         self.send(method, blog_entry, name.to_sym, value) # invoke process_* method
       else
         raise "Missing '#{method}' to handle label '#{key}'"


### PR DESCRIPTION
Fix for the following error when attempting to use mtexport_parser.rb:

joew$ ruby mtexport_parser.rb example.dump 
mtexport_parser.rb:87:in `block in parse_body': Missing 'process_body' to handle label 'BODY' (RuntimeError)
