### PR TITLE
WordPress Utility Class

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,20 +1,24 @@
-Want to move your TypePad.com or MovableType-powered blog somewhere else? 
+# Want to move your [TypePad.com][6] or [MovableType][5] powered blog somewhere else? 
 
-First, you'll need to [export][1] your blog and put it into a convenient data structure.  Here's how to do that:
+## [Export][1] Your Data:
+
+Follow the [instructions][1] at SixApart to export/backup your [MovableType][5] content.  After you've archived your data (mtexport.dump) you can use mtexport to parse entries and images, convert to [Jekyll][2] (recommended), or convert to [WordPress][3] (don't do it).
+
+## Parse Your [MovableType][5] Data:
 
     file = File.read("mtexport.dump")
     mt = MtexportParser.new(file)
     mt.parse
     mt.print_summary
 
-You may want to generate a list of images so you can download them too:
+## Generate a List of Images:
 
     file = File.read("mtexport.dump")
     mt = MtexportParser.new(file)
     mt.parse
     mt.print_fullsize_images
 
-And maybe you want to move it into Jekyll too? That's also easy:
+## Convert to [Jekyll's][2] [Markdown][4] Data Structure:
 
     file = File.read("mtexport.dump")
     mt = MtexportParser.new(file)
@@ -25,11 +29,30 @@ And maybe you want to move it into Jekyll too? That's also easy:
         jekyll.to_markdown(entry)
         puts "Done processing: #{entry[:title]}"
     end
-  
-In fact, running this command will convert an export archive to Jekyll posts into `_posts`:
+
+## Convert to [Jekyll][2] from the Command Line (`_posts`):
 
     ruby mt_to_jekyll.rb <path-to-export>
 
-Viola!
+## Convert to [WordPress'][3] RSS Data Structure:
+
+    file = File.read("mtexport.dump")
+    mt = MtexportParser.new(file)
+    mt.parse
+    wordpress = MtToWordPress.new
+    wordpress.base_url = 'http://foo.com'
+    wordpress.mt_url = 'http://foo.typepad.com'
+    wordpress.image_dir = '/images'
+    wordpress.print_rss(mt)
+
+## Convert to [WordPress][3] RSS from the Command Line:
+
+    ruby mt_to_wordpress.rb <path-to-export> <blog-url> <typepad-url> <image-dir>
+
 
   [1]: http://www.sixapart.com/movabletype/docs/mtimport
+  [2]: http://jekyllrb.com
+  [3]: http://wordpress.org
+  [4]: http://daringfireball.net/projects/markdown/
+  [5]: http://www.sixapart.com/movabletype/
+  [6]: http://www.typepad.com

--- a/example.dump
+++ b/example.dump
@@ -12,7 +12,7 @@ Here is some more text.
 -----
 COMMENT:
 AUTHOR: Foo
-DATE: 01/31/2002 15:47:06
+DATE: 01/31/2002 15:47:06 PM
 This is
 the body of this comment.
 -----
@@ -37,7 +37,7 @@ entry, and here it...
 --------
 TITLE: Here is a new entry
 AUTHOR: Baz Quux
-DATE: 01/31/2002 03:31:05
+DATE: 01/31/2002 03:31:05 AM
 CATEGORY: Politics
 -----
 BODY:
@@ -57,7 +57,7 @@ Here is the first comment on this entry.
 --------
 TITLE: Here is an entry with images
 AUTHOR: Bear Baz
-DATE: 01/31/2014 03:31:05
+DATE: 01/31/2014 03:31:05 PM
 CATEGORY: Politics
 -----
 BODY:
@@ -66,7 +66,7 @@ consist of multiple lines. <a class="asset-img-link" href="http://www.foo.com/.a
 -----
 EXCERPT:
 See, this entry does not have an extended piece; but
-it does have an excerpt. It is special. <a class="asset-img-link" href="http://www.foo.com/.a/anotherreallycrypticstringoflettersandnumbers-popup" onclick="window.open( this.href, &#39;_blank&#39;, &#39;width=640,height=480,scrollbars=no,resizable=no,toolbar=no,directories=no,location=no,menubar=no,status=no,left=0,top=0&#39; ); return false" style="display: inline;"><img alt="Bill_Hang PS" class="asset  asset-image at-xid-anotherreallycrypticstringoflettersandnumbers img-responsive" src="http://www.foo.com/.a/anotherreallycrypticstringoflettersandnumbers-450wi" style="width: 450px;" title="Bear Baz" /></a>
+it does have an excerpt. It is special. <a class="asset-img-link" href="http://foo.typepad.com/.a/anotherreallycrypticstringoflettersandnumbers-popup" onclick="window.open( this.href, &#39;_blank&#39;, &#39;width=640,height=480,scrollbars=no,resizable=no,toolbar=no,directories=no,location=no,menubar=no,status=no,left=0,top=0&#39; ); return false" style="display: inline;"><img alt="Bill_Hang PS" class="asset  asset-image at-xid-anotherreallycrypticstringoflettersandnumbers img-responsive" src="http://www.foo.com/.a/anotherreallycrypticstringoflettersandnumbers-450wi" style="width: 450px;" title="Bear Baz" /></a>
 -----
 COMMENT:
 AUTHOR: Quux

--- a/mt_to_wordpress.rb
+++ b/mt_to_wordpress.rb
@@ -1,0 +1,114 @@
+class MtToWordPress
+
+  RSS_ATTRIBUTES = {:version => '2.0',
+                 'xmlns:excerpt' => 'http://purl.org/rss/1.0/modules/content/',
+                 'xmlns:content' => 'http://purl.org/rss/1.0/modules/content/',
+                     'xmlns:wfw' => "http://wellformedweb.org/CommentAPI/",
+                      'xmlns:dc' => "http://purl.org/dc/elements/1.1/",
+                      'xmlns:wp' => "http://wordpress.org/export/1.2/"}
+
+  def base_url=(url)
+    @base_url = url
+  end
+
+  def mt_url=(url)
+    @mt_url = url
+  end
+  
+  def image_dir=(dir)
+    @image_dir = dir
+  end
+
+  def print_rss(mt)
+    puts build_rss(mt)
+  end
+
+  def build_rss(mt)
+    # inspired/adapted from: https://github.com/chloerei/blog_converter/
+    builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
+      xml.rss(RSS_ATTRIBUTES) do
+        xml.channel do
+          xml['wp'].wxr_version   '1.2'
+          mt.each_blog_post do |entry|
+            xml.item do
+              parsedDate = DateTime.strptime(entry[:date], "%m/%d/%Y %H:%M:%S %p")
+              content = entry[:body]
+              if entry[:extended_body]
+                content = content + "\n<!--more-->\n"
+                content = content + entry[:extended_body]
+              end
+              xml.title               entry[:title]
+              xml.pubDate             parsedDate.rfc2822
+              xml['dc'].creator       {|xml| xml.cdata entry[:author]}
+              xml['content'].encoded  {|xml| xml.cdata normalize_html(content)}
+              xml['excerpt'].encoded  {|xml| xml.cdata normalize_html(entry[:excerpt])}
+              xml['wp'].post_date     parsedDate
+              xml['wp'].post_type     'post'
+              xml['wp'].status        'publish'
+              if entry[:category]
+                entry[:category].each do |cat|
+                  nicename = cat.downcase.gsub(' ','-')
+                  xml.category(:domain => 'category', :nicename => nicename) {|xml| xml.cdata cat}
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    builder.to_xml
+  end
+
+  def normalize_html(content) 
+    haystack = Nokogiri::HTML(content)
+    # remove onclick attributes
+    if haystack.xpath('//@onclick')
+      haystack.xpath('//@onclick').remove
+    end
+    # remove inline style attributes
+    if haystack.xpath('//@style')
+      haystack.xpath('//@style').remove
+    end
+    # look for custom url and typepad url references
+    [@base_url,@mt_url].each do |url|
+      # anchors
+      haystack.css("a").each do |needle|
+        if needle['href']
+          # update relative image link references
+          if needle['href'].include?(url+'/.a')
+            needle['href'] = needle['href'].gsub(url+'/.a', @image_dir) + '.jpg'
+          end
+          # replace popup references with target attribute
+          if needle['href'].include?('-popup')
+            needle['href'] = needle['href'].gsub('-popup','')
+            needle['target'] = '_new'
+          end
+        end
+      end
+      # images
+      haystack.css("img").each do |needle|
+        # update relative image source attributes
+        if needle['src'].include?(url+'/.a')
+          needle['src'] = needle['src'].gsub(url+'/.a', @image_dir) + '.jpg'
+        end
+      end
+    end
+    return haystack.css("body").inner_html
+  end
+
+end
+
+if __FILE__ == $0
+  require 'date'
+  require 'nokogiri'
+  require 'pp'
+  raise "Usage: #{__FILE__} [mt_export] [base_url] [mt_url] [image_dir]" if ARGV.length < 4
+  require File.dirname(__FILE__) + '/mtexport_parser'
+  mt = MtexportParser.new(File.read(ARGV[0]))
+  mt.parse
+  wordpress = MtToWordPress.new
+  wordpress.base_url = ARGV[1]
+  wordpress.mt_url = ARGV[2]
+  wordpress.image_dir = ARGV[3]
+  wordpress.print_rss(mt)
+end


### PR DESCRIPTION
MtToWordPress class for converting TypePad data to WordPress WXR RSS format.  Initial version only supports  content, excerpts, and categories.

MtToWordPress also converts MovableType's image source and anchor attributes to local/relative values.
